### PR TITLE
fix(goreleaser): remove ignore section

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,13 +34,6 @@ builds:
       - '386'
       - arm
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
-      - goos: darwin
-        goarch: '386'
-      - goos: linux
-        goarch: amd64
 archives:
   -
     builds:


### PR DESCRIPTION
fixes #85.

Indeed in https://github.com/YaleUniversity/packer-plugin-goss/pull/79 I added an ignore section which ignored `linux_amd64` intorduced in `v3.2.9`. This MR reverts that change