### PR TITLE
fix(goreleaser): use --clean instead of --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes the broken release CI (https://github.com/YaleUniversity/packer-plugin-goss/actions/runs/9383198273/job/25836269474) by removing the deprecated arg `--rm-dist`